### PR TITLE
Add access to org.freedesktop.ScreenSaver on system D-Bus

### DIFF
--- a/tv.plex.PlexDesktop.yml
+++ b/tv.plex.PlexDesktop.yml
@@ -10,6 +10,7 @@ finish-args:
   - --share=ipc
   - --share=network
   - --talk-name=org.freedesktop.ScreenSaver
+  - --system-talk-name=org.freedesktop.ScreenSaver
 cleanup:
   - /include
   - /bin/cjpeg


### PR DESCRIPTION
I was having an issue where Plex Desktop would not disable the screensaver when using this Flatpak version in Ubuntu. Someone else has reported similar issue in Mint (https://forums.linuxmint.com/viewtopic.php?t=380253) Adding permission to access org.freedesktop.ScreenSaver on both the system and session D-Bus solves this issue for me. I don't know why as no other video player Flatpaks I've looked at seem to need this, but I presume it has something to do with the way screensaver inhibiting was implemented in the app. :shrug: 