### PR TITLE
Update runtime to 23.08

### DIFF
--- a/tv.plex.PlexDesktop.yml
+++ b/tv.plex.PlexDesktop.yml
@@ -1,6 +1,6 @@
 app-id: tv.plex.PlexDesktop
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: Plex
 finish-args:

--- a/tv.plex.PlexDesktop.yml
+++ b/tv.plex.PlexDesktop.yml
@@ -78,8 +78,8 @@ modules:
       - --disable-static
     sources:
       - type: archive
-        url: https://zlib.net/zlib-1.2.13.tar.gz
-        sha256: b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
+        url: https://zlib.net/zlib-1.3.tar.gz
+        sha256: ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
         x-checker-data:
           type: anitya
           project-id: 5303

--- a/tv.plex.PlexDesktop.yml
+++ b/tv.plex.PlexDesktop.yml
@@ -61,15 +61,6 @@ modules:
       - /lib/pkgconfig
       - /lib/cmake
 
-  - name: libwebp
-    buildsystem: autotools
-    config-opts: [--disable-static, --enable-libwebpmux, --enable-libwebpdemux]
-    cleanup: [/share, /bin]
-    sources:
-      - type: archive
-        url: https://github.com/webmproject/libwebp/archive/refs/heads/0.5.1.zip
-        sha256: 55c5abdf0f153b26f89ad593181f0d7ff7aec03d6d51777598fe8d8c63a1eea0
-
   - name: libsnappy
     buildsystem: cmake-ninja
     config-opts:


### PR DESCRIPTION
libwebp is included in the runtime. I don't see a reason for it to be included here. Is there any reason it is on a super old version?

This prevents getting security patches in which are usually fixed in the runtime.

This is in relation to the following security patch which was made available for 23.08

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/commit/023b02df4ae3f27b437503910f7c104dc14282b4