### PR TITLE
Runtime updated to 23.08

### DIFF
--- a/tv.plex.PlexDesktop.yml
+++ b/tv.plex.PlexDesktop.yml
@@ -1,6 +1,6 @@
 app-id: tv.plex.PlexDesktop
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: Plex
 finish-args:


### PR DESCRIPTION
Info: runtime org.freedesktop.Platform branch 21.08 is end-of-life, with reason:
org.freedesktop.Platform 21.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.
Info: applications using this runtime:
tv.plex.PlexDesktop